### PR TITLE
Update build-image.yml

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get More Disk Space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 30720
+          root-reserve-mb: 2048
           swap-size-mb: 1024
           remove-dotnet: 'true'
           remove-android: 'true'


### PR DESCRIPTION
Without workaround should be work on selfhost runner. For github - need more space, 2048mb for dependecies should be enough. give the rest for build, but you can get more disk space from workaround