### PR TITLE
Mention SSH in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Insert your SD card into the slot on the board and power on the device. The firs
 
 ## Login Information
 
-For the server image you will be able to login through HDMI or a serial console connection. The predefined user is `ubuntu` and the password is `ubuntu`.
+For the server image you will be able to login through HDMI, a serial console connection, or SSH. The predefined user is `ubuntu` and the password is `ubuntu`.
 
 For the desktop image you must connect through HDMI and follow the setup-wizard.
 


### PR DESCRIPTION
These images saved me a lot of time getting started on my Rock 5a, thanks! I was thinking it wouldn't work at first, because the README only mentioned logging in via HDMI or serial, and I didn't have the right adapters for either. However, I was excited to see that SSH was enabled by default, which allowed me to get in and configure it headless. This PR just adds a mention of SSH in the README for others like myself :).