### PR TITLE
Add debhelper as docker build dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     cpio \
     debootstrap \
+    debhelper \
     device-tree-compiler \
     dosfstools \
     fakeroot \


### PR DESCRIPTION
Got this error when tried to build kernel using build

`dpkg-checkbuilddeps: error: Unmet build dependencies: debhelper`