### PR TITLE
fix ubuntuEnv.txt load address

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -209,7 +209,7 @@ cat > ${mount_point}/system-boot/boot.cmd << 'EOF'
 # Recompile with:
 # mkimage -A arm64 -O linux -T script -C none -n "Boot Script" -d boot.cmd boot.scr
 
-setenv load_addr "0x9000000"
+setenv load_addr "0x7000000"
 setenv overlay_error "false"
 
 echo "Boot script loaded from ${devtype} ${devnum}"


### PR DESCRIPTION
The current load address of ubuntuEnv is 0x9000000, but in the u-boot released by Rockchip, the default load address of bl32 is set to 0x8400000. So there will be a conflict between these two addresses, and it will crash if the optee support is enabled in the u-boot.