### PR TITLE
Fix building desktop

### DIFF
--- a/config/projects/preinstalled-desktop.sh
+++ b/config/projects/preinstalled-desktop.sh
@@ -17,7 +17,7 @@ function build_rootfs_hook__preinstalled-desktop() {
 
     # Query list of default ubuntu packages
     for task in minimal standard ubuntu-desktop; do
-        for package in $(chroot "${chroot_dir}" apt-cache dumpavail | grep-dctrl -nsPackage \( -XFArchitecture arm64 -o -XFArchitecture all \) -a -wFTask "${task}"); do
+        for package in $(chroot "${chroot_dir}" apt-cache dumpavail | /usr/bin/grep-dctrl -nsPackage \( -XFArchitecture arm64 -o -XFArchitecture all \) -a -wFTask "${task}"); do
             package_list+=("${package}")
         done
     done


### PR DESCRIPTION
For some reason after installing `dctrl-tools` I assume the user environment is not updated and therefore the binary is not found. This has been worked around by adding the full path to `grep-dctrl`. Not ideal, the root cause should still be investigated.

~~Test build is still WIP, however it passed the point where this thing was installed and used already. Will update soon~~
Build successful

Fixes #628 