### PR TITLE
feat: set cgroup to v2 in build-image.sh

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -199,7 +199,7 @@ mkimage -A arm64 -O linux -T script -C none -n "Boot Script" -d ${mount_point}/s
 
 # Uboot env
 cat > ${mount_point}/system-boot/ubuntuEnv.txt << EOF
-bootargs=root=UUID=${root_uuid} rootfstype=ext4 rootwait rw console=ttyS2,1500000 console=tty1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory swapaccount=1 systemd.unified_cgroup_hierarchy=0 ${bootargs}
+bootargs=root=UUID=${root_uuid} rootfstype=ext4 rootwait rw console=ttyS2,1500000 console=tty1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory swapaccount=1 systemd.unified_cgroup_hierarchy=1 ${bootargs}
 fdtfile=${DEVICE_TREE_FILE}
 overlay_prefix=${OVERLAY_PREFIX}
 overlays=


### PR DESCRIPTION
#664 
I tested it locally on my nanopc t6 and it boots and works with podman (similar to docker) which uses cgroup v2 features