### PR TITLE
Enable armsom-sige7 early PD negotiation

### DIFF
--- a/packages/u-boot-radxa-rk3588/debian/patches/0013-add-pd-nego-for-armsom-sige7.patch
+++ b/packages/u-boot-radxa-rk3588/debian/patches/0013-add-pd-nego-for-armsom-sige7.patch
@@ -1,0 +1,166 @@
+diff --git a/arch/arm/dts/rk3588-armsom-sige7.dts b/arch/arm/dts/rk3588-armsom-sige7.dts
+index 36183d0..39400da 100755
+--- a/arch/arm/dts/rk3588-armsom-sige7.dts
++++ b/arch/arm/dts/rk3588-armsom-sige7.dts
+@@ -8,6 +8,7 @@
+ #include "rk3588.dtsi"
+ #include "rk3588-u-boot.dtsi"
+ #include <dt-bindings/input/input.h>
++#include <dt-bindings/usb/pd.h>
+ 
+ / {
+ 	model = "ArmSoM SIGE7";
+@@ -75,6 +76,78 @@
+ 	};
+ };
+ 
++&i2c3 {
++	u-boot,dm-pre-reloc;
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c3m0_xfer>;
++
++	status = "okay";
++
++	usbc0: fusb302@22 {
++		compatible = "fcs,fusb302";
++		u-boot,dm-pre-reloc;
++		reg = <0x22>;
++		interrupt-parent = <&gpio3>;
++		interrupts = <RK_PC4 IRQ_TYPE_LEVEL_LOW>;
++		int-n-gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usbc0_int>;
++		// vbus-supply = <&vcc12v_dcin>;
++		status = "okay";
++
++		usb_con: connector {
++			u-boot,dm-pre-reloc;
++			compatible = "usb-c-connector";
++			label = "USB-C";
++			data-role = "dual";
++			power-role = "sink";
++			try-power-role = "sink";
++			op-sink-microwatt = <1000000>;
++			sink-pdos =
++				<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
++				 PDO_VAR(5000, 12000, 5000)>;
++		};
++	};
++};
++
++&pinctrl {
++	u-boot,dm-pre-reloc;
++	status = "okay";
++
++	usbc {
++		u-boot,dm-pre-reloc;
++		usbc0_int: usbc0-int {
++			u-boot,dm-pre-reloc;
++			rockchip,pins = <3 RK_PC4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++};
++
++&i2c3m0_xfer {
++	u-boot,dm-pre-reloc;
++};
++
++&php_grf {
++	u-boot,dm-pre-reloc;
++};
++
++&ioc {
++	u-boot,dm-pre-reloc;
++};
++
++&cru {
++	u-boot,dm-pre-reloc;
++};
++
++&pcfg_pull_none_smt {
++	u-boot,dm-pre-reloc;
++};
++
++&gpio3 {
++	u-boot,dm-pre-reloc;
++	status = "okay";
++};
++
+ &pcie3x4 {
+ 	u-boot,dm-pre-reloc;
+ 	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
+diff --git a/configs/armsom-sige7-rk3588_defconfig b/configs/armsom-sige7-rk3588_defconfig
+index 50bf9b7..ea5e3c8 100755
+--- a/configs/armsom-sige7-rk3588_defconfig
++++ b/configs/armsom-sige7-rk3588_defconfig
+@@ -31,8 +31,6 @@ CONFIG_SPL_FIT_IMAGE_POST_PROCESS=y
+ CONFIG_SPL_FIT_HW_CRYPTO=y
+ # CONFIG_SPL_SYS_DCACHE_OFF is not set
+ CONFIG_BOOTDELAY=0
+-CONFIG_DISABLE_CONSOLE=y
+-CONFIG_SYS_CONSOLE_INFO_QUIET=y
+ # CONFIG_DISPLAY_CPUINFO is not set
+ CONFIG_ANDROID_BOOTLOADER=y
+ CONFIG_ANDROID_AVB=y
+@@ -84,6 +82,7 @@ CONFIG_SPL_OF_CONTROL=y
+ CONFIG_SPL_DTB_MINIMUM=y
+ CONFIG_OF_LIVE=y
+ CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_OF_U_BOOT_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
+ # CONFIG_NET_TFTP_VARS is not set
+ CONFIG_REGMAP=y
+ CONFIG_SPL_REGMAP=y
+@@ -106,6 +105,7 @@ CONFIG_SPL_SCMI_FIRMWARE=y
+ CONFIG_ROCKCHIP_GPIO=y
+ CONFIG_ROCKCHIP_GPIO_V2=y
+ CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_I2C_MUX=y
+ CONFIG_DM_KEY=y
+ CONFIG_ADC_KEY=y
+ CONFIG_MISC=y
+@@ -152,6 +152,11 @@ CONFIG_PINCTRL=y
+ CONFIG_SPL_PINCTRL=y
+ CONFIG_DM_PMIC=y
+ CONFIG_PMIC_SPI_RK8XX=y
++CONFIG_DM_POWER_DELIVERY=y
++CONFIG_TYPEC_TCPM=y
++CONFIG_TYPEC_TCPCI=y
++CONFIG_TYPEC_HUSB311=y
++CONFIG_TYPEC_FUSB302=y
+ CONFIG_REGULATOR_PWM=y
+ CONFIG_DM_REGULATOR_FIXED=y
+ CONFIG_DM_REGULATOR_GPIO=y
+@@ -215,3 +220,5 @@ CONFIG_RK_AVB_LIBAVB_USER=y
+ CONFIG_OPTEE_CLIENT=y
+ CONFIG_OPTEE_V2=y
+ CONFIG_OPTEE_ALWAYS_USE_SECURITY_PARTITION=y
++CONFIG_CMD_CHARGE_DISPLAY=y
++CONFIG_DM_CHARGE_DISPLAY=y
+diff --git a/drivers/power/power_delivery/tcpm.c b/drivers/power/power_delivery/tcpm.c
+index 22334c6..1b94a40 100644
+--- a/drivers/power/power_delivery/tcpm.c
++++ b/drivers/power/power_delivery/tcpm.c
+@@ -1390,8 +1390,8 @@ static void tcpm_pd_rx_handler(struct tcpm_port *port,
+ 		 */
+ 		if (!!(le16_to_cpu(msg->header) & PD_HEADER_DATA_ROLE) ==
+ 		    (port->data_role == TYPEC_HOST)) {
+-			printf("Data role mismatch, initiating error recovery\n");
+-			tcpm_set_state(port, ERROR_RECOVERY, 0);
++			printf("Data role mismatch, hard resetting...\n");
++			tcpm_set_state(port, HARD_RESET_SEND, 0);
+ 		} else {
+ 			if (cnt)
+ 				tcpm_pd_data_request(port, msg);
+diff --git a/include/configs/rk3588_common.h b/include/configs/rk3588_common.h
+index 275c02a..1a8a647 100644
+--- a/include/configs/rk3588_common.h
++++ b/include/configs/rk3588_common.h
+@@ -86,7 +86,7 @@
+ #define CONFIG_USB_OHCI_NEW
+ #define CONFIG_SYS_USB_OHCI_MAX_ROOT_PORTS	1
+ 
+-#define CONFIG_PREBOOT
++#define CONFIG_PREBOOT "charge_pd"
+ #define CONFIG_LIB_HW_RAND
+ 
+ #endif

--- a/packages/u-boot-radxa-rk3588/debian/patches/series
+++ b/packages/u-boot-radxa-rk3588/debian/patches/series
@@ -10,3 +10,4 @@
 0010-board-add-roc-rk3588s-pc-support.patch
 0011-fix-gcc13-compile-error.patch
 0012-fix-noble-compile-error.patch
+0013-add-pd-nego-for-armsom-sige7.patch


### PR DESCRIPTION
test: 
sudo  ./build.sh  --board=armsom-sige7 --project=preinstalled-desktop --release=jammy --kernel=rockchip-5.10

I added this patch today and tested armsom-sige7, and PD can be started normally during the uboot stage.
![bb9402acbc2c135e74237d347fcdb50](https://github.com/Joshua-Riek/ubuntu-rockchip/assets/108977763/a995402f-d3f7-43b8-a602-9660427d05c4)

[armbian pr](https://github.com/armbian/build/pull/6421)