### PR TITLE
use radxa u-boot latest branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build
         shell: bash
-        run: sudo ./build.sh --suite=${{ matrix.suite }} --flavor=${{ matrix.flavor }} --rootfs-only --launchpad
+        run: sudo ./build.sh --suite=${{ matrix.suite }} --flavor=${{ matrix.flavor }} --rootfs-only
 
       - name: Upload
         uses: actions/upload-artifact@v4.3.1
@@ -57,9 +57,57 @@ jobs:
             path: ./build/ubuntu-${{ matrix.suite == 'jammy' && '22.04' || matrix.suite == 'noble' && '24.04' }}-preinstalled-${{ matrix.flavor }}-arm64.rootfs.tar.xz
             if-no-files-found: error
 
+  kernel:
+    runs-on: ubuntu-latest
+    name: Build kernel 
+    strategy:
+        matrix:
+          suite:
+            - jammy
+            - noble
+    steps:
+      - name: Get more disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Checkout LFS
+        shell: bash
+        run: git lfs fetch && git lfs checkout
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt-get update && sudo apt-get upgrade -y
+          sudo apt-get install -y build-essential gcc-aarch64-linux-gnu bison \
+          qemu-user-static qemu-system-arm qemu-efi u-boot-tools binfmt-support \
+          debootstrap flex libssl-dev bc rsync kmod cpio xz-utils fakeroot parted \
+          udev dosfstools uuid-runtime git-lfs device-tree-compiler python2 python3 \
+          python-is-python3 fdisk bc debhelper python3-pyelftools python3-setuptools \
+          python3-distutils python3-pkg-resources swig libfdt-dev libpython3-dev
+
+      - name: Build
+        shell: bash
+        run: sudo ./build.sh --suite=${{ matrix.suite }} --kernel-only
+
+      - name: Upload
+        uses: actions/upload-artifact@v4.3.1
+        with:
+            name: linux-rockchip-${{ matrix.suite == 'jammy' && '5.10' || matrix.suite == 'noble' && '6.1' }}
+            path: ./build/linux-*.deb
+            if-no-files-found: error
+
   build:
     runs-on: ubuntu-latest
-    needs: [rootfs]
+    needs: [rootfs, kernel]
     name: Build image 
 
     strategy:
@@ -119,6 +167,12 @@ jobs:
             name: ubuntu-${{ matrix.suite == 'jammy' && '22.04' || matrix.suite == 'noble' && '24.04' }}-preinstalled-${{ matrix.flavor }}-arm64-rootfs
             path: ./build/
 
+      - name: Checkout kernel
+        uses: actions/download-artifact@v4.1.2
+        with:
+            name: linux-rockchip-${{ matrix.suite == 'jammy' && '5.10' || matrix.suite == 'noble' && '6.1' }}
+            path: ./build/
+
       - name: Install dependencies
         shell: bash
         run: |
@@ -132,7 +186,7 @@ jobs:
 
       - name: Build
         shell: bash
-        run: sudo ./build.sh --board=${{ matrix.board }} --suite=${{ matrix.suite }} --flavor=${{ matrix.flavor }} --launchpad
+        run: sudo ./build.sh --board=${{ matrix.board }} --suite=${{ matrix.suite }} --flavor=${{ matrix.flavor }}
 
       - name: Upload
         uses: actions/upload-artifact@v4.3.1

--- a/packages/u-boot-radxa-rk3588/debian/upstream
+++ b/packages/u-boot-radxa-rk3588/debian/upstream
@@ -1,4 +1,4 @@
 GIT=https://github.com/radxa/u-boot.git
-COMMIT=cdbe95ed2fac1255bcc8ea8bf29ab58f3912174e
-BRANCH=next-dev
-VERSION=2017.09+20240313.gitcdbe95ed
+COMMIT=d1cf49135ee93d477fef3855ad9c223b26d55e6d
+BRANCH=next-dev-v2024.03
+VERSION=2017.09+20240529.gitd1cf4913


### PR DESCRIPTION
Radxa rock5 series uboot branch has been switched to next-dev-v2024.03.
The latest support of rk3588 has only been committed to this branch.

