### PR TITLE
Adding support to Youyeetoo R1

### DIFF
--- a/config/boards/youyeetoo-r1.sh
+++ b/config/boards/youyeetoo-r1.sh
@@ -1,0 +1,26 @@
+# shellcheck shell=bash
+
+export BOARD_NAME="Youyeetoo R1"
+export BOARD_MAKER="Youyeetoo"
+export BOARD_SOC="Rockchip RK3588S"
+export BOARD_CPU="ARM Cortex A76 / A55"
+export UBOOT_PACKAGE="u-boot-radxa-rk3588"
+export UBOOT_RULES_TARGET="youyeetoo-r1-rk3588s"
+
+function config_image_hook__youyeetoo-r1() {
+    local rootfs="$1"
+
+    # Install panfork
+    chroot "${rootfs}" add-apt-repository -y ppa:jjriek/panfork-mesa
+    chroot "${rootfs}" apt-get update
+    chroot "${rootfs}" apt-get -y install mali-g610-firmware
+    chroot "${rootfs}" apt-get -y dist-upgrade
+
+    # Install libmali blobs alongside panfork
+    chroot "${rootfs}" apt-get -y install libmali-g610-x11
+
+    # Install the rockchip camera engine
+    chroot "${rootfs}" apt-get -y install camera-engine-rkaiq-rk3588
+
+    return 0
+}

--- a/packages/u-boot-radxa-rk3588/debian/control
+++ b/packages/u-boot-radxa-rk3588/debian/control
@@ -174,6 +174,20 @@ Description: A boot loader for the FriendlyELEC NanoPC T6.
  supported architectures, including PPC, ARM, MIPS, x86, m68k,
  NIOS, and Microblaze.
 
+Package: u-boot-youyeetoo-r1
+Architecture: arm64
+Priority: optional
+Depends: mtd-utils
+Provides: u-boot-youyeetoo-rk3588, u-boot
+Replaces: u-boot-youyeetoo-rk3588, u-boot
+Conflicts: u-boot-youyeetoo-rk3588, u-boot
+Description: A boot loader for the Youyeetoo R1.
+ Das U-Boot is a cross-platform bootloader for embedded systems,
+ used as the default boot loader by several board vendors.  It is
+ intended to be easy to port and to debug, and runs on many
+ supported architectures, including PPC, ARM, MIPS, x86, m68k,
+ NIOS, and Microblaze.
+
 Package: u-boot-lubancat-4
 Architecture: arm64
 Priority: optional

--- a/packages/u-boot-radxa-rk3588/debian/targets.mk
+++ b/packages/u-boot-radxa-rk3588/debian/targets.mk
@@ -66,6 +66,11 @@ nanopc-t6-rk3588_ddr := rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin
 nanopc-t6-rk3588_bl31 := rk3588_bl31_v1.45.elf
 nanopc-t6-rk3588_pkg := nanopc-t6
 
+u-boot-rockchip_platforms += youyeetoo-r1-rk3588s
+youyeetoo-r1-rk3588s_ddr := rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin
+youyeetoo-r1-rk3588s_bl31 := rk3588_bl31_v1.45.elf
+youyeetoo-r1-rk3588s_pkg := youyeetoo-r1
+
 u-boot-rockchip_platforms += lubancat-4-rk3588s
 lubancat-4-rk3588s_ddr := rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin
 lubancat-4-rk3588s_bl31 := rk3588_bl31_v1.45.elf


### PR DESCRIPTION
Hi @Joshua-Riek,

I'm sending you this pull request to integrate the Youyeetoo R1. I want to emphasize, as always, that I'm still a beginner and hope to learn here. If you have any suggestions on how to best integrate this board, I'm available for testing since I own one.

From the vendor's SDK, I see a patch, but I think it is related to the fact that the partition table layout is based on Android rather than Linux. I'm not sure if it makes sense to integrate it here.

```bash

From 3ac01579b647ad850ccace06ce24763ee6f71ad5 Mon Sep 17 00:00:00 2001
From: Eddie Cai <eddie.cai.linux@gmail.com>
Date: Thu, 17 Mar 2022 09:53:24 +0800
Subject: [PATCH 2/3] modify export-image to meet rockchip image requirement

---
 export-image/00-allow-rerun/00-run.sh  | 10 +++-
 export-image/03-set-partuuid/00-run.sh |  6 ---
 export-image/04-finalise/01-run.sh     | 30 +++---------
 export-image/prerun.sh                 | 64 +++++---------------------
 4 files changed, 25 insertions(+), 85 deletions(-)

diff --git a/export-image/00-allow-rerun/00-run.sh b/export-image/00-allow-rerun/00-run.sh
index dd67f4c..5174d9b 100755
--- a/export-image/00-allow-rerun/00-run.sh
+++ b/export-image/00-allow-rerun/00-run.sh
@@ -1,7 +1,13 @@
 #!/bin/bash -e
 
-if [ ! -x "${ROOTFS_DIR}/usr/bin/qemu-arm-static" ]; then
-	cp /usr/bin/qemu-arm-static "${ROOTFS_DIR}/usr/bin/"
+if [ "$ARCH" == "armhf" ]; then
+	if [ ! -x "${ROOTFS_DIR}/usr/bin/qemu-arm-static" ]; then
+		cp /usr/bin/qemu-arm-static "${ROOTFS_DIR}/usr/bin/"
+	fi
+elif [ "$ARCH" == "arm64"  ]; then
+	if [ ! -x "${ROOTFS_DIR}/usr/bin/qemu-aarch64-static" ]; then
+		cp /usr/bin/qemu-aarch64-static "${ROOTFS_DIR}/usr/bin/"
+	fi
 fi
 
 if [ -e "${ROOTFS_DIR}/etc/ld.so.preload" ]; then
diff --git a/export-image/03-set-partuuid/00-run.sh b/export-image/03-set-partuuid/00-run.sh
index 16e1b15..28020d6 100755
--- a/export-image/03-set-partuuid/00-run.sh
+++ b/export-image/03-set-partuuid/00-run.sh
@@ -6,13 +6,7 @@ if [ "${NO_PRERUN_QCOW2}" = "0" ]; then
 
 	IMGID="$(dd if="${IMG_FILE}" skip=440 bs=1 count=4 2>/dev/null | xxd -e | cut -f 2 -d' ')"
 
-	BOOT_PARTUUID="${IMGID}-01"
 	ROOT_PARTUUID="${IMGID}-02"
 
-	sed -i "s/BOOTDEV/PARTUUID=${BOOT_PARTUUID}/" "${ROOTFS_DIR}/etc/fstab"
-	sed -i "s/ROOTDEV/PARTUUID=${ROOT_PARTUUID}/" "${ROOTFS_DIR}/etc/fstab"
-
-	sed -i "s/ROOTDEV/PARTUUID=${ROOT_PARTUUID}/" "${ROOTFS_DIR}/boot/cmdline.txt"
-
 fi
 
diff --git a/export-image/04-finalise/01-run.sh b/export-image/04-finalise/01-run.sh
index d7ace58..fa0e191 100755
--- a/export-image/04-finalise/01-run.sh
+++ b/export-image/04-finalise/01-run.sh
@@ -16,7 +16,11 @@ if [ -d "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.config" ]; then
 	chmod 700 "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.config"
 fi
 
-rm -f "${ROOTFS_DIR}/usr/bin/qemu-arm-static"
+if [ "$ARCH" == "armhf" ]; then
+	rm -f "${ROOTFS_DIR}/usr/bin/qemu-arm-static"
+elif [ "$ARCH" == "arm64"  ]; then
+	rm -f "${ROOTFS_DIR}/usr/bin/qemu-aarch64-static"
+fi
 
 if [ "${USE_QEMU}" != "1" ]; then
 	if [ -e "${ROOTFS_DIR}/etc/ld.so.preload.disabled" ]; then
@@ -52,26 +56,9 @@ find "${ROOTFS_DIR}/var/log/" -type f -exec cp /dev/null {} \;
 rm -f "${ROOTFS_DIR}/root/.vnc/private.key"
 rm -f "${ROOTFS_DIR}/etc/vnc/updateid"
 
-update_issue "$(basename "${EXPORT_DIR}")"
-install -m 644 "${ROOTFS_DIR}/etc/rpi-issue" "${ROOTFS_DIR}/boot/issue.txt"
-
-cp "$ROOTFS_DIR/etc/rpi-issue" "$INFO_FILE"
-
 
 {
-	if [ -f "$ROOTFS_DIR/usr/share/doc/raspberrypi-kernel/changelog.Debian.gz" ]; then
-		firmware=$(zgrep "firmware as of" \
-			"$ROOTFS_DIR/usr/share/doc/raspberrypi-kernel/changelog.Debian.gz" | \
-			head -n1 | sed  -n 's|.* \([^ ]*\)$|\1|p')
-		printf "\nFirmware: https://github.com/raspberrypi/firmware/tree/%s\n" "$firmware"
-
-		kernel="$(curl -s -L "https://github.com/raspberrypi/firmware/raw/$firmware/extra/git_hash")"
-		printf "Kernel: https://github.com/raspberrypi/linux/tree/%s\n" "$kernel"
-
-		uname="$(curl -s -L "https://github.com/raspberrypi/firmware/raw/$firmware/extra/uname_string7")"
-		printf "Uname string: %s\n" "$uname"
-	fi
-
+	echo -e "Rockbian ${IMG_DATE}\nGenerated using ${PI_GEN}, ${PI_GEN_REPO}, ${GIT_HASH}, $(basename ${EXPORT_DIR})"
 	printf "\nPackages:\n"
 	dpkg -l --root "$ROOTFS_DIR"
 } >> "$INFO_FILE"
@@ -84,12 +71,7 @@ rm -f "${DEPLOY_DIR}/${IMG_FILENAME}${IMG_SUFFIX}.img"
 mv "$INFO_FILE" "$DEPLOY_DIR/"
 
 if [ "${USE_QCOW2}" = "0" ] && [ "${NO_PRERUN_QCOW2}" = "0" ]; then
-	ROOT_DEV="$(mount | grep "${ROOTFS_DIR} " | cut -f1 -d' ')"
-
 	unmount "${ROOTFS_DIR}"
-	zerofree "${ROOT_DEV}"
-
-	unmount_image "${IMG_FILE}"
 else
 	unload_qimage
 	make_bootable_image "${STAGE_WORK_DIR}/${IMG_FILENAME}${IMG_SUFFIX}.qcow2" "$IMG_FILE"
diff --git a/export-image/prerun.sh b/export-image/prerun.sh
index fad7f80..dde7315 100755
--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -10,8 +10,7 @@ if [ "${NO_PRERUN_QCOW2}" = "0" ]; then
 	rm -rf "${ROOTFS_DIR}"
 	mkdir -p "${ROOTFS_DIR}"
 
-	BOOT_SIZE="$((256 * 1024 * 1024))"
-	ROOT_SIZE=$(du --apparent-size -s "${EXPORT_ROOTFS_DIR}" --exclude var/cache/apt/archives --exclude boot --block-size=1 | cut -f 1)
+	ROOT_SIZE=$(du --apparent-size -s "${EXPORT_ROOTFS_DIR}" --exclude var/cache/apt/archives --block-size=1 | cut -f 1)
 
 	# All partition sizes and starts will be aligned to this size
 	ALIGN="$((4 * 1024 * 1024))"
@@ -19,55 +18,18 @@ if [ "${NO_PRERUN_QCOW2}" = "0" ]; then
 	# some overhead (since actual space usage is usually rounded up to the
 	# filesystem block size) and gives some free space on the resulting
 	# image.
-	ROOT_MARGIN="$(echo "($ROOT_SIZE * 0.2 + 200 * 1024 * 1024) / 1" | bc)"
+	ROOT_MARGIN="$((200 * 1024 * 1024))"
 
-	BOOT_PART_START=$((ALIGN))
-	BOOT_PART_SIZE=$(((BOOT_SIZE + ALIGN - 1) / ALIGN * ALIGN))
-	ROOT_PART_START=$((BOOT_PART_START + BOOT_PART_SIZE))
+	ROOT_PART_START=$((ALIGN))
 	ROOT_PART_SIZE=$(((ROOT_SIZE + ROOT_MARGIN + ALIGN  - 1) / ALIGN * ALIGN))
-	IMG_SIZE=$((BOOT_PART_START + BOOT_PART_SIZE + ROOT_PART_SIZE))
+	IMG_SIZE=$((ROOT_PART_START + ROOT_PART_SIZE))
 
 	truncate -s "${IMG_SIZE}" "${IMG_FILE}"
+	
+	ROOT_OFFSET=${ROOT_PART_START}
+	ROOT_LENGTH=${ROOT_PART_SIZE}
 
-	parted --script "${IMG_FILE}" mklabel msdos
-	parted --script "${IMG_FILE}" unit B mkpart primary fat32 "${BOOT_PART_START}" "$((BOOT_PART_START + BOOT_PART_SIZE - 1))"
-	parted --script "${IMG_FILE}" unit B mkpart primary ext4 "${ROOT_PART_START}" "$((ROOT_PART_START + ROOT_PART_SIZE - 1))"
-
-	PARTED_OUT=$(parted -sm "${IMG_FILE}" unit b print)
-	BOOT_OFFSET=$(echo "$PARTED_OUT" | grep -e '^1:' | cut -d':' -f 2 | tr -d B)
-	BOOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^1:' | cut -d':' -f 4 | tr -d B)
-
-	ROOT_OFFSET=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 2 | tr -d B)
-	ROOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 4 | tr -d B)
-
-	echo "Mounting BOOT_DEV..."
-	cnt=0
-	until BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}"); do
-		if [ $cnt -lt 5 ]; then
-			cnt=$((cnt + 1))
-			echo "Error in losetup for BOOT_DEV.  Retrying..."
-			sleep 5
-		else
-			echo "ERROR: losetup for BOOT_DEV failed; exiting"
-			exit 1
-		fi
-	done
-
-	echo "Mounting ROOT_DEV..."
-	cnt=0
-	until ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}"); do
-		if [ $cnt -lt 5 ]; then
-			cnt=$((cnt + 1))
-			echo "Error in losetup for ROOT_DEV.  Retrying..."
-			sleep 5
-		else
-			echo "ERROR: losetup for ROOT_DEV failed; exiting"
-			exit 1
-		fi
-	done
-
-	echo "/boot: offset $BOOT_OFFSET, length $BOOT_LENGTH"
-	echo "/:     offset $ROOT_OFFSET, length $ROOT_LENGTH"
+	echo "/:     offset $ROOT_OFFSET, length $ROOT_PART_SIZE"
 
 	ROOT_FEATURES="^huge_file"
 	for FEATURE in metadata_csum 64bit; do
@@ -75,13 +37,9 @@ if [ "${NO_PRERUN_QCOW2}" = "0" ]; then
 		ROOT_FEATURES="^$FEATURE,$ROOT_FEATURES"
 	fi
 	done
-	mkdosfs -n boot -F 32 -v "$BOOT_DEV" > /dev/null
-	mkfs.ext4 -L rootfs -O "$ROOT_FEATURES" "$ROOT_DEV" > /dev/null
 
-	mount -v "$ROOT_DEV" "${ROOTFS_DIR}" -t ext4
-	mkdir -p "${ROOTFS_DIR}/boot"
-	mount -v "$BOOT_DEV" "${ROOTFS_DIR}/boot" -t vfat
+	mkfs.ext4 -L rootfs -O "$ROOT_FEATURES" "$IMG_FILE" > /dev/null
 
-	rsync -aHAXx --exclude /var/cache/apt/archives --exclude /boot "${EXPORT_ROOTFS_DIR}/" "${ROOTFS_DIR}/"
-	rsync -rtx "${EXPORT_ROOTFS_DIR}/boot/" "${ROOTFS_DIR}/boot/"
+	mount -v "$IMG_FILE" "${ROOTFS_DIR}" -t ext4
+	rsync -aHAXx --exclude /var/cache/apt/archives "${EXPORT_ROOTFS_DIR}/" "${ROOTFS_DIR}/"
 fi
-- 
2.20.1



```

In any case, any advice or help from you is greatly appreciated.

Thank you.