### PR TITLE
correct help list with flavors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -118,7 +118,7 @@ if [ -n "${SUITE}" ]; then
 fi
 
 if [ "${FLAVOR}" == "help" ]; then
-    for file in config/suites/*; do
+    for file in config/flavors/*; do
         basename "${file%.sh}"
     done
     exit 0


### PR DESCRIPTION
Executing `build.sh` with `FLAVOR=help` should list flavors, not suites