### PR TITLE
bug #1130 - Deactivation of the Qualcomm PD mapper service (pd-mapper.service), because we are on a Rockchip

### DIFF
--- a/config/boards/aio-3588l.sh
+++ b/config/boards/aio-3588l.sh
@@ -25,6 +25,9 @@ function config_image_hook__aio-3588l() {
 
         # Install the rockchip camera engine
         chroot "${rootfs}" apt-get -y install camera-engine-rkaiq-rk3588
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/armsom-aim7.sh
+++ b/config/boards/armsom-aim7.sh
@@ -25,6 +25,9 @@ function config_image_hook__armsom-aim7() {
 
         # Install the rockchip camera engine
         chroot "${rootfs}" apt-get -y install camera-engine-rkaiq-rk3588
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/armsom-sige5.sh
+++ b/config/boards/armsom-sige5.sh
@@ -15,5 +15,8 @@ function config_image_hook__armsom-sige5() {
     # Kernel modules to blacklist
     echo "blacklist panfrost" > "${rootfs}/etc/modprobe.d/panfrost.conf"
 
+    # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+    chroot "${rootfs}" systemctl disable pd-mapper.service
+
     return 0
 }

--- a/config/boards/armsom-sige7.sh
+++ b/config/boards/armsom-sige7.sh
@@ -40,6 +40,9 @@ function config_image_hook__armsom-sige7() {
         cp "${overlay}/usr/lib/scripts/alsa-audio-config" "${rootfs}/usr/lib/scripts/alsa-audio-config"
         cp "${overlay}/usr/lib/systemd/system/alsa-audio-config.service" "${rootfs}/usr/lib/systemd/system/alsa-audio-config.service"
         chroot "${rootfs}" systemctl enable alsa-audio-config
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/armsom-w3.sh
+++ b/config/boards/armsom-w3.sh
@@ -32,6 +32,9 @@ function config_image_hook__armsom-w3() {
         cp "${overlay}/usr/lib/scripts/alsa-audio-config" "${rootfs}/usr/lib/scripts/alsa-audio-config"
         cp "${overlay}/usr/lib/systemd/system/alsa-audio-config.service" "${rootfs}/usr/lib/systemd/system/alsa-audio-config.service"
         chroot "${rootfs}" systemctl enable alsa-audio-config
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/indiedroid-nova.sh
+++ b/config/boards/indiedroid-nova.sh
@@ -32,6 +32,9 @@ function config_image_hook__indiedroid-nova() {
         cp "${overlay}/usr/bin/bt_load_rtk_firmware" "${rootfs}/usr/bin/bt_load_rtk_firmware"
         cp "${overlay}/usr/lib/systemd/system/rtl8821cs-bluetooth.service" "${rootfs}/usr/lib/systemd/system/rtl8821cs-bluetooth.service"
         chroot "${rootfs}" systemctl enable rtl8821cs-bluetooth
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/lubancat-4.sh
+++ b/config/boards/lubancat-4.sh
@@ -25,6 +25,9 @@ function config_image_hook__lubancat-4() {
 
         # Install the rockchip camera engine
         chroot "${rootfs}" apt-get -y install camera-engine-rkaiq-rk3588
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/mixtile-blade3.sh
+++ b/config/boards/mixtile-blade3.sh
@@ -25,6 +25,9 @@ function config_image_hook__mixtile-blade3() {
 
         # Install the rockchip camera engine
         chroot "${rootfs}" apt-get -y install camera-engine-rkaiq-rk3588
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/mixtile-core3588e.sh
+++ b/config/boards/mixtile-core3588e.sh
@@ -25,6 +25,9 @@ function config_image_hook__mixtile-core3588e() {
 
         # Install the rockchip camera engine
         chroot "${rootfs}" apt-get -y install camera-engine-rkaiq-rk3588
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/nanopc-t6.sh
+++ b/config/boards/nanopc-t6.sh
@@ -25,6 +25,9 @@ function config_image_hook__nanopc-t6() {
 
         # Install the rockchip camera engine
         chroot "${rootfs}" apt-get -y install camera-engine-rkaiq-rk3588
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/nanopi-r6c.sh
+++ b/config/boards/nanopi-r6c.sh
@@ -25,6 +25,9 @@ function config_image_hook__nanopi-r6c() {
 
         # Install the rockchip camera engine
         chroot "${rootfs}" apt-get -y install camera-engine-rkaiq-rk3588
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/nanopi-r6s.sh
+++ b/config/boards/nanopi-r6s.sh
@@ -25,6 +25,9 @@ function config_image_hook__nanopi-r6s() {
 
         # Install the rockchip camera engine
         chroot "${rootfs}" apt-get -y install camera-engine-rkaiq-rk3588
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/orangepi-3b.sh
+++ b/config/boards/orangepi-3b.sh
@@ -30,6 +30,9 @@ function config_image_hook__orangepi-3b() {
         # Install wiring orangepi package 
         chroot "${rootfs}" apt-get -y install wiringpi-opi libwiringpi2-opi libwiringpi-opi-dev
         echo "BOARD=orangepi3b" > "${rootfs}/etc/orangepi-release"
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/orangepi-5-max.sh
+++ b/config/boards/orangepi-5-max.sh
@@ -42,6 +42,9 @@ function config_image_hook__orangepi-5-max() {
         # Install wiring orangepi package 
         chroot "${rootfs}" apt-get -y install wiringpi-opi libwiringpi2-opi libwiringpi-opi-dev
         echo "BOARD=orangepi5max" > "${rootfs}/etc/orangepi-release"
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/orangepi-5-plus.sh
+++ b/config/boards/orangepi-5-plus.sh
@@ -36,6 +36,9 @@ function config_image_hook__orangepi-5-plus() {
         # Install wiring orangepi package 
         chroot "${rootfs}" apt-get -y install wiringpi-opi libwiringpi2-opi libwiringpi-opi-dev
         echo "BOARD=orangepi5plus" > "${rootfs}/etc/orangepi-release"
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/orangepi-5-pro.sh
+++ b/config/boards/orangepi-5-pro.sh
@@ -39,6 +39,9 @@ function config_image_hook__orangepi-5-pro() {
         # Install wiring orangepi package 
         chroot "${rootfs}" apt-get -y install wiringpi-opi libwiringpi2-opi libwiringpi-opi-dev
         echo "BOARD=orangepi5pro" > "${rootfs}/etc/orangepi-release"
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/orangepi-5.sh
+++ b/config/boards/orangepi-5.sh
@@ -42,6 +42,9 @@ function config_image_hook__orangepi-5() {
         # Install wiring orangepi package 
         chroot "${rootfs}" apt-get -y install wiringpi-opi libwiringpi2-opi libwiringpi-opi-dev
         echo "BOARD=orangepi5" > "${rootfs}/etc/orangepi-release"
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/orangepi-5b.sh
+++ b/config/boards/orangepi-5b.sh
@@ -41,6 +41,9 @@ function config_image_hook__orangepi-5b() {
         # Install wiring orangepi package 
         chroot "${rootfs}" apt-get -y install wiringpi-opi libwiringpi2-opi libwiringpi-opi-dev
         echo "BOARD=orangepi5" > "${rootfs}/etc/orangepi-release"
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/orangepi-cm5.sh
+++ b/config/boards/orangepi-cm5.sh
@@ -29,6 +29,9 @@ function config_image_hook__orangepi-cm5() {
         # Install wiring orangepi package 
         chroot "${rootfs}" apt-get -y install wiringpi-opi libwiringpi2-opi libwiringpi-opi-dev
         echo "BOARD=orangepicm5" > "${rootfs}/etc/orangepi-release"
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/radxa-cm5-io.sh
+++ b/config/boards/radxa-cm5-io.sh
@@ -32,6 +32,9 @@ function config_image_hook__radxa-cm5-io() {
         cp "${overlay}/usr/lib/scripts/alsa-audio-config" "${rootfs}/usr/lib/scripts/alsa-audio-config"
         cp "${overlay}/usr/lib/systemd/system/alsa-audio-config.service" "${rootfs}/usr/lib/systemd/system/alsa-audio-config.service"
         chroot "${rootfs}" systemctl enable alsa-audio-config
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/radxa-cm5-rpi-cm4-io.sh
+++ b/config/boards/radxa-cm5-rpi-cm4-io.sh
@@ -32,6 +32,9 @@ function config_image_hook__radxa-cm5-rpi-cm4-io() {
         cp "${overlay}/usr/lib/scripts/alsa-audio-config" "${rootfs}/usr/lib/scripts/alsa-audio-config"
         cp "${overlay}/usr/lib/systemd/system/alsa-audio-config.service" "${rootfs}/usr/lib/systemd/system/alsa-audio-config.service"
         chroot "${rootfs}" systemctl enable alsa-audio-config
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/radxa-nx5-io.sh
+++ b/config/boards/radxa-nx5-io.sh
@@ -25,6 +25,9 @@ function config_image_hook__radxa-nx-io() {
 
         # Install the rockchip camera engine
         chroot "${rootfs}" apt-get -y install camera-engine-rkaiq-rk3588
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/radxa-zero3.sh
+++ b/config/boards/radxa-zero3.sh
@@ -34,6 +34,9 @@ function config_image_hook__radxa-zero3() {
         cp "${overlay}/usr/lib/scripts/aic8800-bluetooth.sh" "${rootfs}/usr/lib/scripts/aic8800-bluetooth.sh"
         cp "${overlay}/usr/lib/systemd/system/aic8800-bluetooth.service" "${rootfs}/usr/lib/systemd/system/aic8800-bluetooth.service"
         chroot "${rootfs}" systemctl enable aic8800-bluetooth
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/roc-rk3588s-pc.sh
+++ b/config/boards/roc-rk3588s-pc.sh
@@ -25,6 +25,9 @@ function config_image_hook__roc-rk3588s-pc() {
 
         # Install the rockchip camera engine
         chroot "${rootfs}" apt-get -y install camera-engine-rkaiq-rk3588
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
     return 0
 }

--- a/config/boards/rock-5-itx.sh
+++ b/config/boards/rock-5-itx.sh
@@ -25,6 +25,9 @@ function config_image_hook__rock-5-itx() {
 
         # Install the rockchip camera engine
         chroot "${rootfs}" apt-get -y install camera-engine-rkaiq-rk3588
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/rock-5a.sh
+++ b/config/boards/rock-5a.sh
@@ -37,6 +37,9 @@ function config_image_hook__rock-5a() {
         cp "${overlay}/usr/lib/scripts/alsa-audio-config" "${rootfs}/usr/lib/scripts/alsa-audio-config"
         cp "${overlay}/usr/lib/systemd/system/alsa-audio-config.service" "${rootfs}/usr/lib/systemd/system/alsa-audio-config.service"
         chroot "${rootfs}" systemctl enable alsa-audio-config
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/rock-5b-plus.sh
+++ b/config/boards/rock-5b-plus.sh
@@ -32,6 +32,9 @@ function config_image_hook__rock-5b-plus() {
         cp "${overlay}/usr/lib/scripts/alsa-audio-config" "${rootfs}/usr/lib/scripts/alsa-audio-config"
         cp "${overlay}/usr/lib/systemd/system/alsa-audio-config.service" "${rootfs}/usr/lib/systemd/system/alsa-audio-config.service"
         chroot "${rootfs}" systemctl enable alsa-audio-config
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/rock-5b.sh
+++ b/config/boards/rock-5b.sh
@@ -36,6 +36,9 @@ function config_image_hook__rock-5b() {
         cp "${overlay}/usr/lib/scripts/alsa-audio-config" "${rootfs}/usr/lib/scripts/alsa-audio-config"
         cp "${overlay}/usr/lib/systemd/system/alsa-audio-config.service" "${rootfs}/usr/lib/systemd/system/alsa-audio-config.service"
         chroot "${rootfs}" systemctl enable alsa-audio-config
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/rock-5c.sh
+++ b/config/boards/rock-5c.sh
@@ -38,6 +38,9 @@ function config_image_hook__rock-5c() {
         cp "${overlay}/usr/lib/scripts/alsa-audio-config" "${rootfs}/usr/lib/scripts/alsa-audio-config"
         cp "${overlay}/usr/lib/systemd/system/alsa-audio-config.service" "${rootfs}/usr/lib/systemd/system/alsa-audio-config.service"
         chroot "${rootfs}" systemctl enable alsa-audio-config
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/rock-5d.sh
+++ b/config/boards/rock-5d.sh
@@ -38,6 +38,9 @@ function config_image_hook__rock-5d() {
         cp "${overlay}/usr/lib/scripts/alsa-audio-config" "${rootfs}/usr/lib/scripts/alsa-audio-config"
         cp "${overlay}/usr/lib/systemd/system/alsa-audio-config.service" "${rootfs}/usr/lib/systemd/system/alsa-audio-config.service"
         chroot "${rootfs}" systemctl enable alsa-audio-config
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0

--- a/config/boards/turing-rk1.sh
+++ b/config/boards/turing-rk1.sh
@@ -28,8 +28,14 @@ function config_image_hook__turing-rk1() {
 
         # The RK1 uses UART9 for console output
         sed -i 's/console=ttyS2,1500000/console=ttyS9,115200/g' "${rootfs}/etc/kernel/cmdline"
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     elif [ "${suite}" == "oracular" ]; then
         sed -i 's/console=ttyS2,1500000/console=ttyS0,115200/g' "${rootfs}/etc/kernel/cmdline"
+
+        # Deactivate the Qualcomm PD mapper service, because we are on a Rockchip.
+        chroot "${rootfs}" systemctl disable pd-mapper.service
     fi
 
     return 0


### PR DESCRIPTION
Possible solution for bug #1130 (Bug Report: pd-mapper.service failed to start during boot).

Deactivation of the Qualcomm PD mapper service (pd-mapper.service)